### PR TITLE
Support regular-expression-like strings as regular expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = function deepMatch(obj, example) {
   if (example instanceof RegExp) return example.test(obj || '');
 
   // If the example is a regular expression-like string
-  if (REGEX.test(example)) {
+  // Ignore arrays because REGEX.test([/a+/]) === true
+  if (REGEX.test(example) && !(example instanceof Array)) {
     var matches = example.match(REGEX);
     return new RegExp(matches[1], matches[2]).test(obj || '');
   }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,17 @@
+var REGEX = /\/(.*?)\/([gimy]*)?$/;
+
 module.exports = function deepMatch(obj, example) {
   // If the example is a function, execute it
   if (typeof example === 'function') return example(obj);
 
   // If the example is a regular expression, match it
   if (example instanceof RegExp) return example.test(obj || '');
+
+  // If the example is a regular expression-like string
+  if (REGEX.test(example)) {
+    var matches = example.match(REGEX);
+    return new RegExp(matches[1], matches[2]).test(obj || '');
+  }
 
   // Identitical values always match.
   if (obj === example) return true;

--- a/test/index.js
+++ b/test/index.js
@@ -86,6 +86,14 @@ describe('deep-match', () => {
     expect(match(['aaa', 'bbb'], [/a+/, /c+/]), 'to be false');
   });
 
+  it('should execute regular-expression-like strings as regular expressions ', () => {
+    expect(match('aaa', '/a+/'), 'to be true');
+    expect(match('aaa', '/b+/'), 'to be false');
+    expect(match(['aaa', 'bbb'], ['/a+/']), 'to be true');
+    expect(match(['aaa', 'bbb'], ['/a+/', '/b+/']), 'to be true');
+    expect(match(['aaa', 'bbb'], ['/a+/', '/c+/']), 'to be false');
+  });
+
   it('should execute functions', () => {
     function isOne(value) {
       return value === 1;


### PR DESCRIPTION
Hi - this PR extends the deep-match lib to support regular-expression-like strings, ie `'/a+/'`
In our use case the regular expressions get serialized to strings before we pass them to deep-match. Apparently they won't be recognized currently.

thanks
Andreas
