### PR TITLE
Feature/array order matters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
  {
   "extends": "airbnb/legacy",
+  "env": {
+    "es6": true
+  },
   "rules": {
     "comma-dangle": [2, "never"],
     "consistent-return": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,5 @@
  {
   "extends": "airbnb/legacy",
-  "env": {
-    "es6": true
-  },
   "rules": {
     "comma-dangle": [2, "never"],
     "consistent-return": 0,

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -34,6 +34,31 @@ deepMatch([1, 2, 3], [v => v === 1]); // true
 
 ```
 
+When matching arrays order of items do not matters by default. To change it you can use additional parameter:
+
+```js
+let opts = { arrayOrderMatters: true };
+deepMatch([1, 2], [1, 2], opts); // true
+deepMatch([1, 2], [2, 1], opts); // false
+deepMatch([1, 2], [   2], opts); // false
+
+// disable checks for undefined items
+// [,2] is the same as [undefined, 2]
+deepMatch([1, 2], [ , 2], opts); // true
+
+// arrayOrderMatters applies also to nested arrays:
+source  = { a1: [ {i1: []}, {i2: [1, 2, [31, 32, 33], 4, 5]} ]};
+matcher = { a1: [ {i1: []}, {i2: [1,  , [32, 33    ],  , 5]} ]};
+deepMatch(source, matcher, opts); // false
+deepMatch(source, matcher);       // true
+
+source  = { a1: [ {i1: []}, {i2: [1, 2, [31, 32, 33], 4, 5]} ]};
+matcher = { a1: [ {i1: []}, {i2: [1,  , [31,   , 33],  , 5]} ]};
+deepMatch(source, matcher, opts); // true
+deepMatch(source, matcher);       // true
+
+```
+
 ## Rules
 
 Values are compared according to the following rules:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Values are compared according to the following rules:
 * Values of different types never match.
 * Values that are no objects only match if they are identical (see above).
 * Null values (which are also objects) only match if both are null.
-* Arrays match if all items in the example match.
+* Arrays match if all items in the example match (note different behavior for option `arrayOrderMatters`).
 * Objects match if all properties in the example match.
 
 # License

--- a/README.md
+++ b/README.md
@@ -47,15 +47,16 @@ deepMatch([1, 2], [   2], opts); // false
 deepMatch([1, 2], [ , 2], opts); // true
 
 // arrayOrderMatters applies also to nested arrays:
-source  = { a1: [ {i1: []}, {i2: [1, 2, [31, 32, 33], 4, 5]} ]};
-matcher = { a1: [ {i1: []}, {i2: [1,  , [32, 33    ],  , 5]} ]};
+source  = { a1: [ {i1: []}, {i2: [1, 2,         [31, 32, 33], 4, 5]} ]};
+matcher = { a1: [ {i1: []}, {i2: [1, undefined, [32, 33    ],  , 5]} ]};
 deepMatch(source, matcher, opts); // false
-deepMatch(source, matcher);       // true
+deepMatch(source, matcher);       // false
 
-source  = { a1: [ {i1: []}, {i2: [1, 2, [31, 32, 33], 4, 5]} ]};
-matcher = { a1: [ {i1: []}, {i2: [1,  , [31,   , 33],  , 5]} ]};
+// Note that in case of arrayOrderMatters=false undefined is not skipped
+source  = { a1: [ {i1: []}, {i2: [1, 2,         [31, 32,        33], 4, 5]} ]};
+matcher = { a1: [ {i1: []}, {i2: [1, undefined, [31, undefined, 33],  , 5]} ]};
 deepMatch(source, matcher, opts); // true
-deepMatch(source, matcher);       // true
+deepMatch(source, matcher);       // false
 
 ```
 
@@ -68,6 +69,8 @@ Values are compared according to the following rules:
 * Values that are no objects only match if they are identical (see above).
 * Null values (which are also objects) only match if both are null.
 * Arrays match if all items in the example match (note different behavior for option `arrayOrderMatters`).
+* When `arrayOrderMatters=true` value of `undefined` matchers are skipped.
+* When `arrayOrderMatters=false` (default behavior) value of `undefined` matchers are NOT skipped.
 * Objects match if all properties in the example match.
 
 # License

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,6 @@
+declare module 'deep-match' {
+    export type DeepMatchOpts = {
+        arrayOrderMatters?: boolean;
+    }
+    export default function deepMatch(source: any, match: any | ((source: any) => boolean), opts?: DeepMatchOpts): boolean
+}

--- a/index.js
+++ b/index.js
@@ -21,25 +21,22 @@ module.exports = function deepMatch(obj, example, opts = {}) {
 
   // Arrays match if all items in the example match.
   if (example instanceof Array) {
-
     if (arrayOrderMatters) {
-
       // Array should be compared in strict order
       for (let [index, exampleItem] of example.entries()) {
         let objItem = obj[index];
+        // this lets you skip validation for particular array items eg: [ , ,'validate']
         if (exampleItem === undefined) {
-          // this lets you skip validation for particular array items eg: [ , ,'validate']
           continue;
         }
-        if ( ! deepMatch(objItem, exampleItem, opts)) {
+        if (!deepMatch(objItem, exampleItem, opts)) {
           return false;
         }
       }
       return true;
     }
-    else {
 
-      // Array order does not matter
+    if (!arrayOrderMatters) {
       return example.every(function (item) {
         return obj instanceof Array && obj.some(function (o) {
           return deepMatch(o, item, opts);

--- a/index.js
+++ b/index.js
@@ -23,10 +23,9 @@ module.exports = function deepMatch(obj, example, opts) {
   if (example instanceof Array) {
     if (arrayOrderMatters) {
       // Array should be compared in strict order
-      for (var exampleEntry of example.entries()) {
-        var index = exampleEntry[0];
-        var exampleItem = exampleEntry[1];
-        var objItem = obj[index];
+      for (var i = 0; i < example.length; i++) {
+        var exampleItem = example[i];
+        var objItem = obj[i];
         // this lets you skip validation for particular array items eg: [ , ,'validate']
         if (exampleItem === undefined) {
           continue;

--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ module.exports = function deepMatch(obj, example, opts) {
   if (example instanceof Array) {
     if (arrayOrderMatters) {
       // Array should be compared in strict order
-      for (var [index, exampleItem] of example.entries()) {
+      for (var exampleEntry of example.entries()) {
+        var index = exampleEntry[0];
+        var exampleItem = exampleEntry[1];
         var objItem = obj[index];
         // this lets you skip validation for particular array items eg: [ , ,'validate']
         if (exampleItem === undefined) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-module.exports = function deepMatch(obj, example, opts = {}) {
-  const { arrayOrderMatters = false } = opts;
+module.exports = function deepMatch(obj, example, opts) {
+  var arrayOrderMatters = (opts && opts.arrayOrderMatters) || false;
 
   // If the example is a function, execute it
   if (typeof example === 'function') return example(obj);
@@ -23,8 +23,8 @@ module.exports = function deepMatch(obj, example, opts = {}) {
   if (example instanceof Array) {
     if (arrayOrderMatters) {
       // Array should be compared in strict order
-      for (let [index, exampleItem] of example.entries()) {
-        let objItem = obj[index];
+      for (var [index, exampleItem] of example.entries()) {
+        var objItem = obj[index];
         // this lets you skip validation for particular array items eg: [ , ,'validate']
         if (exampleItem === undefined) {
           continue;

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -2,5 +2,8 @@
   "extends": "airbnb/base",
   "env": {
     "mocha": true
+  },
+  "rules": {
+    "no-var": 0
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -99,3 +99,63 @@ describe('deep-match', () => {
     expect(match([2, 3], [isOne]), 'to be false');
   });
 });
+
+describe('deep-match arrayOrderMatters', () => {
+
+  it('should match basic array', () => {
+
+    let source  = [1, 2];
+    let matcher = [1, 2];
+    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be true');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
+    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+
+    source  = [1, 2];
+    matcher = [2, 1];
+    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be false');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
+    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+  });
+
+  it('should skip matching undefined items', () => {
+
+    let source =  [];
+    let matcher = [];
+    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be true');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
+    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+
+    source  = [1, 2, 3, 4, 5];
+    matcher = [ , 2,  , 4];
+    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be true');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
+    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+
+    source  = [1, 2, 3, 4, 5];
+    matcher = [ , 2, 4];
+    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be false');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
+    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+  });
+
+  it('should match nested arrays', () => {
+
+    let source  = { v1: 'val', a1: [ {i1: []}, {i2: [1, 2, [31, 32, 33], 4, 5]} ]};
+    let matcher = { v1: 'val', a1: [ {i2: [1]}                                  ]};
+    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be false');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
+    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+
+    source  = { v1: 'val', a1: [ {i1: []}, {i2: [1, 2, [31, 32, 33], 4, 5]} ]};
+    matcher = { v1: 'val', a1: [ {i1: []}, {i2: [1,  , [  , 32, 33],  , 5]} ]};
+    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be true');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
+    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+
+    source  = { v1: 'val', a1: [ {i1: []}, {i2: [1, 2, [31, 32, 33], 4, 5]} ]};
+    matcher = { v1: 'val', a1: [ {i1: []}, {i2: [1,  , [32, 33    ],  , 5]} ]};
+    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be false');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
+    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -104,8 +104,8 @@ describe('deep-match arrayOrderMatters', () => {
   // default behavior should be the same as using { arrayOrderMatters: false }
 
   it('should match basic array', () => {
-    let source = [1, 2];
-    let matcher = [1, 2];
+    var source = [1, 2];
+    var matcher = [1, 2];
     expect(match(source, matcher, { arrayOrderMatters: true }), 'to be true');
     expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
     expect(match(source, matcher), 'to be true');
@@ -118,8 +118,8 @@ describe('deep-match arrayOrderMatters', () => {
   });
 
   it('should skip matching undefined items', () => {
-    let source = [];
-    let matcher = [];
+    var source = [];
+    var matcher = [];
     expect(match(source, matcher, { arrayOrderMatters: true }), 'to be true');
     expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
     expect(match(source, matcher), 'to be true');
@@ -138,8 +138,8 @@ describe('deep-match arrayOrderMatters', () => {
   });
 
   it('should match nested arrays', () => {
-    let source = { v1: 'val', a1: [{ i1: [] }, { i2: [1, 2, [31, 32, 33], 4, 5] }] };
-    let matcher = { v1: 'val', a1: [{ i2: [1] }] };
+    var source = { v1: 'val', a1: [{ i1: [] }, { i2: [1, 2, [31, 32, 33], 4, 5] }] };
+    var matcher = { v1: 'val', a1: [{ i2: [1] }] };
     expect(match(source, matcher, { arrayOrderMatters: true }), 'to be false');
     expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
     expect(match(source, matcher), 'to be true');

--- a/test/index.js
+++ b/test/index.js
@@ -61,19 +61,19 @@ describe('deep-match', () => {
 
   it('should handle undefined and null values', () => {
     expect(match(undefined, ''), 'to be false');
-    expect(match(undefined, {}), 'to be false');
+    expect(match(undefined, { }), 'to be false');
     expect(match(undefined, []), 'to be false');
     expect(match(undefined, /undefined/), 'to be false');
     expect(match(null, ''), 'to be false');
-    expect(match(null, {}), 'to be false');
+    expect(match(null, { }), 'to be false');
     expect(match(null, []), 'to be false');
     expect(match(null, /null/), 'to be false');
     expect(match('', undefined), 'to be false');
-    expect(match({}, undefined), 'to be false');
+    expect(match({ }, undefined), 'to be false');
     expect(match([], undefined), 'to be false');
     expect(match(/u/, undefined), 'to be false');
     expect(match('', null), 'to be false');
-    expect(match({}, null), 'to be false');
+    expect(match({ }, null), 'to be false');
     expect(match([], null), 'to be false');
     expect(match(/u/, null), 'to be false');
   });
@@ -101,61 +101,68 @@ describe('deep-match', () => {
 });
 
 describe('deep-match arrayOrderMatters', () => {
+  // default behavior should be the same as using { arrayOrderMatters: false }
 
   it('should match basic array', () => {
-
-    let source  = [1, 2];
+    let source = [1, 2];
     let matcher = [1, 2];
-    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be true');
+    expect(match(source, matcher, { arrayOrderMatters: true }), 'to be true');
     expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
-    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+    expect(match(source, matcher), 'to be true');
 
-    source  = [1, 2];
+    source = [1, 2];
     matcher = [2, 1];
-    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be false');
+    expect(match(source, matcher, { arrayOrderMatters: true }), 'to be false');
     expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
-    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+    expect(match(source, matcher), 'to be true');
   });
 
   it('should skip matching undefined items', () => {
-
-    let source =  [];
+    let source = [];
     let matcher = [];
-    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be true');
+    expect(match(source, matcher, { arrayOrderMatters: true }), 'to be true');
     expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
-    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+    expect(match(source, matcher), 'to be true');
 
-    source  = [1, 2, 3, 4, 5];
-    matcher = [ , 2,  , 4];
-    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be true');
-    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
-    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+    source = [1, 2, 3, 4, 5];
+    matcher = [undefined, 2, undefined, 4];
+    expect(match(source, matcher, { arrayOrderMatters: true }), 'to be true');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be false');
+    expect(match(source, matcher), 'to be false');
 
-    source  = [1, 2, 3, 4, 5];
-    matcher = [ , 2, 4];
-    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be false');
-    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
-    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+    source = [1, 2, 3, 4, 5];
+    matcher = [undefined, 2, 4];
+    expect(match(source, matcher, { arrayOrderMatters: true }), 'to be false');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be false');
+    expect(match(source, matcher), 'to be false');
   });
 
   it('should match nested arrays', () => {
-
-    let source  = { v1: 'val', a1: [ {i1: []}, {i2: [1, 2, [31, 32, 33], 4, 5]} ]};
-    let matcher = { v1: 'val', a1: [ {i2: [1]}                                  ]};
-    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be false');
+    let source = { v1: 'val', a1: [{ i1: [] }, { i2: [1, 2, [31, 32, 33], 4, 5] }] };
+    let matcher = { v1: 'val', a1: [{ i2: [1] }] };
+    expect(match(source, matcher, { arrayOrderMatters: true }), 'to be false');
     expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
-    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+    expect(match(source, matcher), 'to be true');
 
-    source  = { v1: 'val', a1: [ {i1: []}, {i2: [1, 2, [31, 32, 33], 4, 5]} ]};
-    matcher = { v1: 'val', a1: [ {i1: []}, {i2: [1,  , [  , 32, 33],  , 5]} ]};
-    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be true');
-    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
-    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+    source = { v1: 'val', a1: [{ i1: [] }, { i2: [1, 2, [31, 32, 33], 4, 5] }] };
+    matcher = {
+      v1: 'val',
+      a1: [{ i1: [] }, { i2: [1, undefined, [undefined, 32, 33], undefined, 5] }],
+    };
+    expect(match(source, matcher, { arrayOrderMatters: true }), 'to be true');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be false');
+    expect(match(source, matcher), 'to be false');
 
-    source  = { v1: 'val', a1: [ {i1: []}, {i2: [1, 2, [31, 32, 33], 4, 5]} ]};
-    matcher = { v1: 'val', a1: [ {i1: []}, {i2: [1,  , [32, 33    ],  , 5]} ]};
-    expect(match(source, matcher, { arrayOrderMatters: true }),  'to be false');
+    source = { v1: 'val', a1: [{ i1: [] }, { i2: [1, 2, [31, 32, 33], 4, 5] }] };
+    matcher = { v1: 'val', a1: [{ i1: [] }, { i2: [1, undefined, [32, 33], undefined, 5] }] };
+    expect(match(source, matcher, { arrayOrderMatters: true }), 'to be false');
+    expect(match(source, matcher, { arrayOrderMatters: false }), 'to be false');
+    expect(match(source, matcher), 'to be false');
+
+    source = { v1: 'val', a1: [{ i1: [] }, { i2: [1, 2, [31, 32, 33], 4, 5] }] };
+    matcher = { v1: 'val', a1: [{ i1: [] }, { i2: [1, 2, [31, 32, 33], 4, 5] }] };
+    expect(match(source, matcher, { arrayOrderMatters: true }), 'to be true');
     expect(match(source, matcher, { arrayOrderMatters: false }), 'to be true');
-    expect(match(source, matcher),                               'to be true'); // default should be the same as { arrayOrderMatters: false }
+    expect(match(source, matcher), 'to be true');
   });
 });


### PR DESCRIPTION
I found it useful when order of items in arrays matters.

This change introduce:

additional options parameter that changes behavior of array comparison
backward compatibility is kept (options are optional and default options are set to original behavior)
tests added
readme updated
typescript definition added so module can be imported into typescript project (index.d.ts file)
For more details check readme and tests